### PR TITLE
Fix undefined password_confirmation key in reset password flow

### DIFF
--- a/app/Http/Requests/Auth/CreateNewPasswordRequest.php
+++ b/app/Http/Requests/Auth/CreateNewPasswordRequest.php
@@ -28,6 +28,7 @@ final class CreateNewPasswordRequest extends FormRequest
             'token' => ['required'],
             'email' => ['required', 'email'],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'password_confirmation' => ['required'],
         ];
     }
 }


### PR DESCRIPTION
## Summary
- add `password_confirmation` to `CreateNewPasswordRequest` validation rules
- ensures the field is included in `$request->validated()`
- prevents `Undefined array key "password_confirmation"` in `CreateNewPasswordAction`

## Why
`CreateNewPasswordAction` expects `password_confirmation` in the input array. With only the `confirmed` rule on `password`, Laravel validates confirmation but does not include `password_confirmation` in `validated()` unless it has its own rule.

## Impact
- fixes reset-password error
- no behavior change to successful validation logic (password still must match confirmation)
