### PR TITLE
Fix Rx Final: display ALT BIF values on prescription show page

### DIFF
--- a/resources/js/pages/prescriptions/show.tsx
+++ b/resources/js/pages/prescriptions/show.tsx
@@ -225,7 +225,7 @@ export default function PrescriptionShow({ prescription, company }: Props) {
                                         {prescription.subjetivo_od_add ?? '-'}
                                     </td>
                                     <td className="border border-gray-900 px-2 py-2.5 text-center text-sm text-gray-900 dark:border-gray-500 dark:text-gray-100">
-                                        -
+                                        {prescription.alt_bif_od ?? '-'}
                                     </td>
                                     <td className="border border-gray-900 px-2 py-2.5 text-center text-sm text-gray-900 dark:border-gray-500 dark:text-gray-100">
                                         {prescription.subjetivo_od_av_lejos ? `20/${prescription.subjetivo_od_av_lejos}` : '-'}
@@ -251,7 +251,7 @@ export default function PrescriptionShow({ prescription, company }: Props) {
                                         {prescription.subjetivo_oi_add ?? '-'}
                                     </td>
                                     <td className="border border-gray-900 px-2 py-2.5 text-center text-sm text-gray-900 dark:border-gray-500 dark:text-gray-100">
-                                        -
+                                        {prescription.alt_bif_oi ?? '-'}
                                     </td>
                                     <td className="border border-gray-900 px-2 py-2.5 text-center text-sm text-gray-900 dark:border-gray-500 dark:text-gray-100">
                                         {prescription.subjetivo_oi_av_lejos ? `20/${prescription.subjetivo_oi_av_lejos}` : '-'}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -829,6 +829,7 @@ export interface Prescription {
     subjetivo_od_eje?: string;
     subjetivo_od_add?: string;
     subjetivo_od_dp?: string;
+    alt_bif_od?: string;
     subjetivo_od_av_lejos?: string;
     subjetivo_od_av_cerca?: string;
 
@@ -837,6 +838,7 @@ export interface Prescription {
     subjetivo_oi_eje?: string;
     subjetivo_oi_add?: string;
     subjetivo_oi_dp?: string;
+    alt_bif_oi?: string;
     subjetivo_oi_av_lejos?: string;
     subjetivo_oi_av_cerca?: string;
 }


### PR DESCRIPTION
## Summary\n- fix prescription show page to render  and  in the Rx Final table\n- remove hardcoded  placeholders in the ALT BIF column\n- update  TypeScript type to include  and \n\n## Problem\nWhen creating/editing a prescription, ALT BIF values were saved but not displayed in the Rx Final UI because the show page hardcoded  for both eyes.\n\n## Result\nALT BIF now appears correctly for OD/OI on the prescription show screen and stays type-safe in TS.