### PR TITLE
Add workflow job detail links on contact process tab

### DIFF
--- a/resources/js/pages/contacts/show.tsx
+++ b/resources/js/pages/contacts/show.tsx
@@ -511,7 +511,12 @@ export default function ContactShow({ contact, invoices, quotations, prescriptio
                                                                 <p className="text-xs text-gray-500">{job.workflow_stage?.name || 'Etapa actual'}</p>
                                                             </div>
                                                         </div>
-                                                        <div className="flex items-center gap-3">{getPriorityBadge(job.priority)}</div>
+                                                        <div className="flex items-center gap-3">
+                                                            {getPriorityBadge(job.priority)}
+                                                            <Link href={`/workflows/${job.workflow_id}/jobs/${job.id}`}>
+                                                                <ChevronRight className="h-4 w-4 text-gray-400" />
+                                                            </Link>
+                                                        </div>
                                                     </div>
                                                 ))}
 
@@ -1012,6 +1017,9 @@ export default function ContactShow({ contact, invoices, quotations, prescriptio
                                                                 Cancelado
                                                             </Badge>
                                                         )}
+                                                        <Link href={`/workflows/${job.workflow_id}/jobs/${job.id}`}>
+                                                            <ChevronRight className="h-4 w-4 text-gray-400" />
+                                                        </Link>
                                                     </div>
                                                 </div>
                                             ))}


### PR DESCRIPTION
## Summary\n- add direct links to workflow job detail pages from Contact > Procesos list\n- add the same direct link in Recent Activity workflow items\n\n## Why\nThe contact page showed process cards but did not provide a direct navigation path to the job detail page, making it harder to open a specific process quickly.