### PR TITLE
Fix workflow job create: save select custom-field values correctly

### DIFF
--- a/resources/js/components/workflows/dynamic-fields.tsx
+++ b/resources/js/components/workflows/dynamic-fields.tsx
@@ -68,7 +68,7 @@ export function DynamicFields({ fields, values, onChange }: DynamicFieldsProps) 
                         </SelectTrigger>
                         <SelectContent>
                             {field.mastertable?.items?.map((item) => (
-                                <SelectItem key={item.id} value={item.name}>
+                                <SelectItem key={item.id} value={String(item.id)}>
                                     {item.name}
                                 </SelectItem>
                             ))}


### PR DESCRIPTION
## Summary\n- fix DynamicFields select values in workflow job create dialog\n- store selected mastertable item **id** instead of item name\n\n## Root cause\nThe create dialog ( -> ) sent  for select fields, while workflow job show/edit expects select metadata values as  strings.\n\n## Result\nSelect-type metadata chosen during job creation now persists consistently and appears selected on the workflow job detail page.