### PR TITLE
Use SearchableSelect for workflow custom select fields (create + show)

### DIFF
--- a/resources/js/components/workflows/dynamic-fields.tsx
+++ b/resources/js/components/workflows/dynamic-fields.tsx
@@ -1,7 +1,7 @@
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { SearchableSelect } from '@/components/ui/searchable-select';
 import { Textarea } from '@/components/ui/textarea';
 import type { WorkflowField } from '@/types';
 
@@ -62,18 +62,17 @@ export function DynamicFields({ fields, values, onChange }: DynamicFieldsProps) 
 
             case 'select':
                 return (
-                    <Select value={String(value)} onValueChange={(v) => onChange(field.key, v || null)}>
-                        <SelectTrigger>
-                            <SelectValue placeholder={field.placeholder ?? 'Seleccionar...'} />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {field.mastertable?.items?.map((item) => (
-                                <SelectItem key={item.id} value={String(item.id)}>
-                                    {item.name}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
+                    <SearchableSelect
+                        options={(field.mastertable?.items ?? []).map((item) => ({
+                            value: String(item.id),
+                            label: item.name,
+                        }))}
+                        value={value !== null && value !== undefined ? String(value) : ''}
+                        onValueChange={(v) => onChange(field.key, v || null)}
+                        placeholder={field.placeholder ?? 'Seleccionar...'}
+                        searchPlaceholder="Buscar opción..."
+                        emptyText="No se encontraron opciones"
+                    />
                 );
 
             case 'boolean':

--- a/resources/js/pages/workflow-jobs/show.tsx
+++ b/resources/js/pages/workflow-jobs/show.tsx
@@ -30,7 +30,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { ImageUpload } from '@/components/ui/image-upload';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { SearchableSelect } from '@/components/ui/searchable-select';
 import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
 import AppLayout from '@/layouts/app-layout';
@@ -859,18 +859,17 @@ export default function WorkflowJobShow({ workflow, job, events }: Props) {
                                                                 )}
 
                                                                 {field.type === 'select' && field.mastertable?.items && (
-                                                                    <Select value={String(currentValue)} onValueChange={(v) => handleFieldChange(v)}>
-                                                                        <SelectTrigger>
-                                                                            <SelectValue placeholder={field.placeholder || 'Seleccionar...'} />
-                                                                        </SelectTrigger>
-                                                                        <SelectContent>
-                                                                            {field.mastertable.items.map((item) => (
-                                                                                <SelectItem key={item.id} value={String(item.id)}>
-                                                                                    {item.name}
-                                                                                </SelectItem>
-                                                                            ))}
-                                                                        </SelectContent>
-                                                                    </Select>
+                                                                    <SearchableSelect
+                                                                        options={field.mastertable.items.map((item) => ({
+                                                                            value: String(item.id),
+                                                                            label: item.name,
+                                                                        }))}
+                                                                        value={String(currentValue)}
+                                                                        onValueChange={(v) => handleFieldChange(v)}
+                                                                        placeholder={field.placeholder || 'Seleccionar...'}
+                                                                        searchPlaceholder="Buscar opción..."
+                                                                        emptyText="No se encontraron opciones"
+                                                                    />
                                                                 )}
 
                                                                 {field.type === 'boolean' && (


### PR DESCRIPTION
## Summary\n- replace custom field  inputs with  in workflow job create modal\n- replace custom field  inputs with  in workflow job show/edit page\n- keep values as mastertable item ids for consistency\n\n## Context\nThe searchable variant is better UX for longer option lists and keeps create/show behavior aligned.