### PR TITLE
Fix product total price calculation for values like 1.000 / 1,000

### DIFF
--- a/resources/js/pages/products/create.tsx
+++ b/resources/js/pages/products/create.tsx
@@ -69,7 +69,21 @@ export default function ProductsCreate({ taxes, workspace_stocks }: Props) {
     };
 
     const normalizeAmount = (value: string): string => {
-        return value.replace(/,/g, '');
+        const raw = value.trim().replace(/\s/g, '');
+        if (raw === '') return '';
+
+        // Locale patterns like 1.234 or 1.234,56 => remove thousand separators and normalize decimal comma.
+        if (/^\d{1,3}(\.\d{3})+(,\d+)?$/.test(raw)) {
+            return raw.replace(/\./g, '').replace(',', '.');
+        }
+
+        // Locale patterns like 1,234 or 1,234.56 => remove thousand separators.
+        if (/^\d{1,3}(,\d{3})+(\.\d+)?$/.test(raw)) {
+            return raw.replace(/,/g, '');
+        }
+
+        // Fallback: keep decimal point style expected by JS Number().
+        return raw.replace(/,/g, '');
     };
 
     const { data, setData, post, processing, errors, reset } = useForm({

--- a/resources/js/pages/products/edit.tsx
+++ b/resources/js/pages/products/edit.tsx
@@ -74,7 +74,21 @@ export default function ProductsEdit({ product, taxes, workspace_stocks }: Props
     };
 
     const normalizeAmount = (value: string): string => {
-        return value.replace(/,/g, '');
+        const raw = value.trim().replace(/\s/g, '');
+        if (raw === '') return '';
+
+        // Locale patterns like 1.234 or 1.234,56 => remove thousand separators and normalize decimal comma.
+        if (/^\d{1,3}(\.\d{3})+(,\d+)?$/.test(raw)) {
+            return raw.replace(/\./g, '').replace(',', '.');
+        }
+
+        // Locale patterns like 1,234 or 1,234.56 => remove thousand separators.
+        if (/^\d{1,3}(,\d{3})+(\.\d+)?$/.test(raw)) {
+            return raw.replace(/,/g, '');
+        }
+
+        // Fallback: keep decimal point style expected by JS Number().
+        return raw.replace(/,/g, '');
     };
 
     const { data, setData, put, processing, errors } = useForm({


### PR DESCRIPTION
## Summary
- improve amount normalization in product create/edit price handlers
- correctly parse locale-style thousand separators (`1.000`, `1,000`)
- preserve decimal parsing behavior for common formats

## Problem
When entering total price values like `1000` in locale-formatted flows (for example `1.000`), parsing could treat it as `1.000` (one) instead of one thousand, breaking base-price back-calculation.

## Result
Total-to-base calculation now handles thousand-separated values consistently in both create and edit pages.
