### PR TITLE
Add payment series per workspace and use it on payment PDF

### DIFF
--- a/app/Actions/CreatePaymentAction.php
+++ b/app/Actions/CreatePaymentAction.php
@@ -4,14 +4,18 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Enums\DocumentType;
 use App\Enums\PaymentStatus;
 use App\Enums\PaymentType;
 use App\Exceptions\ReportableActionException;
 use App\Jobs\RecalculateBankAccount;
 use App\Models\BankAccount;
+use App\Models\DocumentSubtype;
 use App\Models\Invoice;
 use App\Models\Payment;
+use App\Models\Workspace;
 use App\Models\WithholdingType;
+use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\DB;
 
 final readonly class CreatePaymentAction
@@ -24,23 +28,25 @@ final readonly class CreatePaymentAction
         return DB::transaction(function () use ($invoice, $data): Payment {
             $paymentType = PaymentType::from($data['payment_type']);
             $account = BankAccount::query()->findOrFail($data['bank_account_id']);
+            /** @var Workspace|null $workspace */
+            $workspace = Context::get('workspace');
 
             if ($paymentType === PaymentType::InvoicePayment) {
-                $payment = $this->createInvoicePayment($invoice, $data, $account);
+                $payment = $this->createInvoicePayment($invoice, $data, $account, $workspace);
 
                 $invoice->updatePaymentStatus();
 
                 return $payment;
             }
 
-            return $this->createOtherIncomePayment($data, $account);
+            return $this->createOtherIncomePayment($data, $account, $workspace);
         });
     }
 
     /**
      * Create a payment for an invoice.
      */
-    private function createInvoicePayment(?Invoice $invoice, array $data, BankAccount $account): Payment
+    private function createInvoicePayment(?Invoice $invoice, array $data, BankAccount $account, ?Workspace $workspace): Payment
     {
         if (! $invoice) {
             throw new ReportableActionException('La factura es requerida para este tipo de pago.');
@@ -52,7 +58,7 @@ final readonly class CreatePaymentAction
 
         $payment = Payment::query()->create([
             'payment_type' => PaymentType::InvoicePayment,
-            'payment_number' => $this->generatePaymentNumber(),
+            'payment_number' => $this->generatePaymentNumber($workspace),
             'invoice_id' => $invoice->id,
             'bank_account_id' => $data['bank_account_id'],
             'currency_id' => $account->currency_id,
@@ -74,7 +80,7 @@ final readonly class CreatePaymentAction
     /**
      * Create a payment for other income (non-invoice).
      */
-    private function createOtherIncomePayment(array $data, BankAccount $account): Payment
+    private function createOtherIncomePayment(array $data, BankAccount $account, ?Workspace $workspace): Payment
     {
         // Calculate totals from lines
         $subtotal = 0;
@@ -105,7 +111,7 @@ final readonly class CreatePaymentAction
 
         $payment = Payment::query()->create([
             'payment_type' => PaymentType::OtherIncome,
-            'payment_number' => $this->generatePaymentNumber(),
+            'payment_number' => $this->generatePaymentNumber($workspace),
             'contact_id' => $data['contact_id'] ?? null,
             'bank_account_id' => $data['bank_account_id'],
             'currency_id' => $account->currency_id,
@@ -171,20 +177,40 @@ final readonly class CreatePaymentAction
     }
 
     /**
-     * Generate a unique payment number.
+     * Generate a payment number using workspace payment series when available.
      */
-    private function generatePaymentNumber(): string
+    private function generatePaymentNumber(?Workspace $workspace): string
     {
+        if ($workspace instanceof Workspace) {
+            $documentSubtype = DocumentSubtype::query()
+                ->where('type', DocumentType::Payment)
+                ->whereHas('workspaces', function ($query) use ($workspace): void {
+                    $query->where('workspaces.id', $workspace->id);
+                })
+                ->orderByDesc('is_default')
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->first();
+
+            if ($documentSubtype instanceof DocumentSubtype) {
+                $paymentNumber = $documentSubtype->prefix.mb_str_pad((string) $documentSubtype->next_number, 4, '0', STR_PAD_LEFT);
+                $documentSubtype->increment('next_number');
+
+                return $paymentNumber;
+            }
+        }
+
         $lastPayment = Payment::query()
             ->select(['id', 'payment_number'])
             ->whereNotNull('payment_number')
             ->orderBy('id', 'desc')
+            ->lockForUpdate()
             ->first();
 
         $lastNumber = 0;
         if ($lastPayment && ! empty($lastPayment->getAttribute('payment_number'))) {
             $paymentNumber = $lastPayment->getAttribute('payment_number');
-            $lastNumber = (int) mb_substr($paymentNumber, 4);
+            $lastNumber = (int) mb_substr((string) $paymentNumber, 4);
         }
 
         return 'PAG-'.mb_str_pad((string) ($lastNumber + 1), 6, '0', STR_PAD_LEFT);

--- a/app/Enums/DocumentType.php
+++ b/app/Enums/DocumentType.php
@@ -8,6 +8,7 @@ enum DocumentType: string
 {
     case Invoice = 'invoice';
     case Quotation = 'quotation';
+    case Payment = 'payment';
 
     /**
      * Get all document types as an array for form options.
@@ -19,6 +20,7 @@ enum DocumentType: string
         return [
             self::Invoice->value => self::Invoice->label(),
             self::Quotation->value => self::Quotation->label(),
+            self::Payment->value => self::Payment->label(),
         ];
     }
 
@@ -30,6 +32,7 @@ enum DocumentType: string
         return match ($this) {
             self::Invoice => 'Factura',
             self::Quotation => 'Cotización',
+            self::Payment => 'Pago',
         };
     }
 }

--- a/database/migrations/tenant/2026_03_03_214026_add_payment_document_subtype_series_per_workspace.php
+++ b/database/migrations/tenant/2026_03_03_214026_add_payment_document_subtype_series_per_workspace.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\DocumentType;
+use App\Models\DocumentSubtype;
+use App\Models\Workspace;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('document_subtypes', function (Blueprint $table): void {
+            $table->string('prefix', 10)->change();
+        });
+
+        $workspaces = Workspace::query()->select(['id', 'name', 'slug'])->get();
+
+        foreach ($workspaces as $workspace) {
+            $seed = strtoupper((string) ($workspace->slug ?: $workspace->name));
+            $seed = preg_replace('/[^A-Z0-9]/', '', $seed) ?: 'WS';
+            $workspaceCode = substr($seed, 0, 2);
+            $basePrefix = 'RPS'.$workspaceCode;
+
+            $prefix = $basePrefix;
+            $suffix = 1;
+            while (DocumentSubtype::query()->where('prefix', $prefix)->exists()) {
+                $prefix = substr($basePrefix, 0, 8).$suffix;
+                $suffix++;
+            }
+
+            $subtype = DocumentSubtype::query()->create([
+                'name' => 'Recibo de pago - '.$workspace->name,
+                'type' => DocumentType::Payment->value,
+                'is_default' => false,
+                'valid_until_date' => null,
+                'prefix' => $prefix,
+                'start_number' => 1,
+                'end_number' => null,
+                'next_number' => 1,
+            ]);
+
+            $workspace->documentSubtypes()->syncWithoutDetaching([
+                $subtype->id => ['is_preferred' => false],
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $paymentSubtypes = DocumentSubtype::query()
+            ->where('type', DocumentType::Payment->value)
+            ->where('name', 'like', 'Recibo de pago - %')
+            ->get();
+
+        foreach ($paymentSubtypes as $subtype) {
+            $subtype->workspaces()->detach();
+            $subtype->delete();
+        }
+
+        Schema::table('document_subtypes', function (Blueprint $table): void {
+            $table->string('prefix', 3)->change();
+        });
+    }
+};

--- a/resources/views/payments/pdf.blade.php
+++ b/resources/views/payments/pdf.blade.php
@@ -301,7 +301,7 @@
             <td style="width: 180px; vertical-align: middle;">
                 <div class="receipt-box">
                     <div class="receipt-title">RECIBO DE CAJA</div>
-                    <div class="receipt-number">No. {{ $payment->id }}</div>
+                    <div class="receipt-number">No. {{ $payment->payment_number ?? $payment->id }}</div>
                 </div>
             </td>
         </tr>


### PR DESCRIPTION
## Summary
- add `payment` document type support
- add a tenant migration that seeds a default payment document subtype per workspace
- attach each payment subtype to its workspace and initialize numbering from 1
- extend `document_subtypes.prefix` to support longer payment prefixes (e.g. `RPSDQ`)
- generate payment numbers from the workspace payment subtype sequence during payment creation
- update `resources/views/payments/pdf.blade.php` to render `payment_number` instead of hardcoded `id`

## Result
Payments now use workspace-specific series (example format: `RPSDQ0001`) and the PDF receipt shows that series number.
