### PR TITLE
fix: use route model binding for user and workspace in BusinessUserWorkspaceRoleController

### DIFF
--- a/app/Http/Controllers/BusinessUserWorkspaceRoleController.php
+++ b/app/Http/Controllers/BusinessUserWorkspaceRoleController.php
@@ -20,14 +20,11 @@ final class BusinessUserWorkspaceRoleController
      */
     public function update(
         UpdateUserWorkspaceRolesRequest $request,
-        int $userId,
-        int $workspaceId,
+        User $user,
+        Workspace $workspace,
         UpdateBusinessUserWorkspaceRolesAction $action,
         #[CurrentUser] User $currentUser,
     ): RedirectResponse {
-        $user = User::findOrFail($userId);
-        $workspace = Workspace::findOrFail($workspaceId);
-
         if (! in_array($currentUser->business_role, [UserRole::Owner, UserRole::Admin])) {
             abort(403, 'Solo el propietario del negocio puede modificar roles.');
         }


### PR DESCRIPTION
## Problema

`BusinessUserWorkspaceRoleController::update()` esperaba `int $userId` e `int $workspaceId`, pero la ruta `PATCH /business/users/{user}/workspaces/{workspace}/roles` resuelve el `{workspace}` mediante el slug gracias a `Workspace::getRouteKeyName()`.

Request: `PATCH /business/users/12/workspaces/covi-principal/roles`

El valor `"covi-principal"` no puede convertirse a `int`, causando un **TypeError** en PHP 8.4 con declaraciones de tipo estrictas.

## Solución

Cambiar los parámetros a `User $user` y `Workspace $workspace` para usar el **route model binding implícito** de Laravel, que:
1. Resuelve `User` por ID (el route key por defecto)
2. Resuelve `Workspace` por slug (tal como lo define `getRouteKeyName()`)

Esto además elimina las llamadas manuales a `User::findOrFail()` y `Workspace::findOrFail()`.

## Consistencia

El controlador `BusinessUserWorkspaceController@destroy` —que usa la misma ruta `business/users/{user}/workspaces/{workspace}`— ya implementaba correctamente este patrón.